### PR TITLE
Avoid to display "move" button from "Shared by Link" page

### DIFF
--- a/css/mv.css
+++ b/css/mv.css
@@ -23,3 +23,6 @@
 	margin: 0;
 	padding: 0;
 }
+#body-public .action-move {
+    display: none !important;
+}


### PR DESCRIPTION
Fix: Issues 24